### PR TITLE
Fixed issue where 'exog' was not moved to GPU memory when using cuda

### DIFF
--- a/pyPLNmodels/_utils.py
+++ b/pyPLNmodels/_utils.py
@@ -306,11 +306,11 @@ def _format_model_param(
     exog = _format_data(exog)
     if add_const is True:
         if exog is None:
-            exog = torch.ones(endog.shape[0], 1)
+            exog = torch.ones(endog.shape[0], 1, device=DEVICE)
         else:
             if _has_null_variance(exog) is False:
                 exog = torch.concat(
-                    (exog, torch.ones(endog.shape[0]).unsqueeze(1)), dim=1
+                    (exog, torch.ones(endog.shape[0], device=DEVICE).unsqueeze(1)), dim=1
                 )
     if offsets is None:
         if offsets_formula == "logsum":

--- a/pyPLNmodels/models.py
+++ b/pyPLNmodels/models.py
@@ -205,7 +205,7 @@ class _model(ABC):
         if self._get_max_components() < 2:
             raise RuntimeError("Can't perform visualization for dim < 2.")
         pca = self.sk_PCA(n_components=2)
-        proj_variables = pca.transform(self.latent_variables)
+        proj_variables = pca.transform(self.latent_variables.cpu())
         x = proj_variables[:, 0]
         y = proj_variables[:, 1]
         sns.scatterplot(x=x, y=y, hue=colors, ax=ax)
@@ -503,7 +503,7 @@ class _model(ABC):
                 f"You ask more components ({n_components}) than variables ({self.dim})"
             )
         pca = self.sk_PCA(n_components=n_components)
-        proj_variables = pca.transform(self.latent_variables)
+        proj_variables = pca.transform(self.latent_variables.cpu())
         components = torch.from_numpy(pca.components_)
 
         labels = {
@@ -563,7 +563,7 @@ class _model(ABC):
 
         n_components = 2
         pca = self.sk_PCA(n_components=n_components)
-        variables = self.latent_variables
+        variables = self.latent_variables.cpu()
         proj_variables = pca.transform(variables)
         ## the package is not correctly printing the variance ratio
         figure, correlation_matrix = plot_pca_correlation_graph(


### PR DESCRIPTION
I ran into an issue using this library on ubuntu with a CUDA enabled GPU with the error:
`Expected all tensors to be on the same device, but found at least two devices, cpu and cuda:0! (when checking argument for argument mat2 in method wrapper_CUDA_mm)`
I traced the issue back to lines 309 and 313 of _utils.py where exog was not sent to DEVICE, unlike offsets and latent_mean. I added device=DEVICE to both instances where exog could be created.

I then found several instances where self.latent_variables was not moved back to CPU memory for use in visualization features, and fixed these so all the code in the provided Getting Started notebook would run without producing the above error.